### PR TITLE
Implement chat state cleanup

### DIFF
--- a/src/main/java/org/dungeon/prototype/async/AsyncJobHandler.java
+++ b/src/main/java/org/dungeon/prototype/async/AsyncJobHandler.java
@@ -179,9 +179,18 @@ public class AsyncJobHandler {
         });
     }
 
-    @Async
     public void clearLatch(long chatId) {
         log.info("Clearing latch for chatId: {}", chatId);
         chatConcurrentStateMap.get(chatId).setLatch(null);
+    }
+
+    public void removeChatState(long chatId) {
+        log.info("Removing chat state for chatId: {}", chatId);
+        if (chatConcurrentStateMap.containsKey(chatId)) {
+            val state = chatConcurrentStateMap.remove(chatId);
+            if (nonNull(state.getGridSectionsQueue())) {
+                state.getGridSectionsQueue().clear();
+            }
+        }
     }
 }

--- a/src/main/java/org/dungeon/prototype/service/state/ChatStateService.java
+++ b/src/main/java/org/dungeon/prototype/service/state/ChatStateService.java
@@ -157,6 +157,7 @@ public class ChatStateService {
                 }
             }
             asyncJobHandler.clearLatch(chatId);
+            asyncJobHandler.removeChatState(chatId);
             chatState.setChatState(IDLE);
             chatState.setLastActiveTime(new AtomicLong(System.currentTimeMillis()));
             chatStateByIdMap.put(chatId, chatState);


### PR DESCRIPTION
## Summary
- add synchronous cleanup for chat-specific async tasks
- ensure chat state removal when clearing chat context
- run gradle tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68443caeda748333962e6e706aca792b