### PR TITLE
Add virtual thread metrics

### DIFF
--- a/grafana/provisioning/dashboards/dungeon-jvm-metrics.json
+++ b/grafana/provisioning/dashboards/dungeon-jvm-metrics.json
@@ -1894,6 +1894,30 @@
           "legendFormat": "process",
           "refId": "D",
           "step": 2400
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "jvm_threads_virtual_threads{application=\"$application\", instance=\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "virtual",
+          "refId": "E",
+          "step": 2400
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "expr": "jvm_threads_carrier_threads{application=\"$application\", instance=\"$instance\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "carrier",
+          "refId": "F",
+          "step": 2400
         }
       ],
       "title": "Threads",

--- a/src/main/java/org/dungeon/prototype/config/AsyncConfig.java
+++ b/src/main/java/org/dungeon/prototype/config/AsyncConfig.java
@@ -66,9 +66,15 @@ public class AsyncConfig {
 
     @Bean
     public Gauge activeVirtualThreadsGauge(MeterRegistry registry) {
-        AtomicInteger activeThreads = new AtomicInteger(Thread.activeCount());
-        return Gauge.builder("jfr_virtual_threads", activeThreads, AtomicInteger::get)
+        return Gauge.builder("jfr_virtual_threads", this::countVirtualThreads)
                 .description("The number of virtual threads in the JVM")
+                .baseUnit("threads")
                 .register(registry);
+    }
+
+    private long countVirtualThreads() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(Thread::isVirtual)
+                .count();
     }
 }

--- a/src/main/java/org/dungeon/prototype/config/VirtualThreadMetrics.java
+++ b/src/main/java/org/dungeon/prototype/config/VirtualThreadMetrics.java
@@ -11,16 +11,19 @@ public class VirtualThreadMetrics {
         // Register a gauge to track total number of threads
         Gauge.builder("jvm.threads.total", Thread::activeCount)
                 .description("Total number of active threads, including virtual threads")
+                .baseUnit("threads")
                 .register(meterRegistry);
 
         // Register a gauge to track the number of virtual threads
         Gauge.builder("jvm.threads.virtual", this::countVirtualThreads)
                 .description("Total number of active virtual threads")
+                .baseUnit("threads")
                 .register(meterRegistry);
 
         // Gauge for carrier threads
         Gauge.builder("jvm.threads.carrier", this::countCarrierThreads)
                 .description("The number of carrier threads used by virtual threads")
+                .baseUnit("threads")
                 .register(meterRegistry);
     }
 


### PR DESCRIPTION
## Summary
- register thread gauges with base units
- improve virtual threads gauge in async config
- show virtual/carrier threads on Grafana JVM dashboard

## Testing
- `bash ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844b6db9c98833385f7e0f3268c2df3