### PR TITLE
Fix scope handling during level generation

### DIFF
--- a/src/main/java/org/dungeon/prototype/async/scoped/ChatTaskManager.java
+++ b/src/main/java/org/dungeon/prototype/async/scoped/ChatTaskManager.java
@@ -53,6 +53,14 @@ public class ChatTaskManager {
     }
 
     /**
+     * Removes scope from internal storage without closing it.
+     * Should be used when the scope lifecycle is managed externally.
+     */
+    public void removeScope(long chatId) {
+        scopes.remove(chatId);
+    }
+
+    /**
      * StructuredTaskScope wrapper storing task information.
      */
     public static class ChatTaskScope extends StructuredTaskScope<Object> {


### PR DESCRIPTION
## Summary
- add a method in `ChatTaskManager` for removing scopes that are closed externally
- manage `ChatTaskScope` with try-with-resources in `LevelGenerationService`

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc1d24b08333a35c67934a5e76a2