### PR TITLE
Embed walkers into cluster

### DIFF
--- a/src/main/java/org/dungeon/prototype/model/level/generation/LevelGridCluster.java
+++ b/src/main/java/org/dungeon/prototype/model/level/generation/LevelGridCluster.java
@@ -1,18 +1,24 @@
 package org.dungeon.prototype.model.level.generation;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.dungeon.prototype.model.Point;
 import org.dungeon.prototype.model.level.ui.GridSection;
 import org.dungeon.prototype.model.weight.Weight;
 import org.dungeon.prototype.service.UniqueIdFactory;
+import org.dungeon.prototype.service.level.generation.WalkerBuilder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 import static org.apache.commons.math3.util.FastMath.abs;
+import static org.dungeon.prototype.util.RandomUtil.getRandomInt;
 
 @Data
+@Slf4j
 public class LevelGridCluster {
     private long id;
     private Point startConnectionPoint;
@@ -21,6 +27,7 @@ public class LevelGridCluster {
     int negativeRoomsCount = 0;
     List<GridSection> deadEnds = new ArrayList<>();
     Weight clusterExpectedWeight;
+    List<WalkerBuilder> walkers = new ArrayList<>();
     public LevelGridCluster(Point startConnectionPoint, Point endConnectionPoint) {
         this.id = UniqueIdFactory.getInstance().getNextId();
         this.startConnectionPoint = startConnectionPoint;
@@ -72,6 +79,79 @@ public class LevelGridCluster {
 
     public void addDeadEnds(List<GridSection> processedDeadEnds) {
         deadEnds.addAll(processedDeadEnds);
+    }
+
+    public void initializeWalkers() {
+        log.info("Initializing walkers for cluster {}", id);
+        walkers = new ArrayList<>();
+        if (isSmallCluster()) {
+            log.info("Small cluster, adding two border walkers...");
+            walkers = Arrays.asList(WalkerBuilder.builder()
+                            .pathFromStart(0)
+                            .isReversed(false)
+                            .cluster(this)
+                            .longestPathDefault(true)
+                            .currentPoint(new Point(0, 0))
+                            .build(),
+                    WalkerBuilder.builder()
+                            .pathFromStart(0)
+                            .isReversed(false)
+                            .longestPathDefault(true)
+                            .cluster(this)
+                            .currentPoint(new Point(0, 0))
+                            .build());
+            return;
+        }
+        if (hasSmallSide()) {
+            log.info("Small sided cluster, adding start and end walkers...");
+            walkers = Arrays.asList(WalkerBuilder.builder()
+                            .pathFromStart(0)
+                            .isReversed(false)
+                            .cluster(this)
+                            .longestPathDefault(false)
+                            .currentPoint(new Point(0, 0))
+                            .build(),
+                    WalkerBuilder.builder()
+                            .isReversed(true)
+                            .longestPathDefault(true)
+                            .pathFromStart(0)
+                            .cluster(this)
+                            .currentPoint(new Point(endConnectionPoint.getX() - startConnectionPoint.getX(),
+                                    endConnectionPoint.getY() - startConnectionPoint.getY()))
+                            .build());
+            return;
+        }
+        int fromStartWalkersNumber = getRandomInt(1, 2);
+        int fromEndWalkersNumber = getRandomInt(1, 3 - fromStartWalkersNumber);
+        log.info("Adding {} walkers to start of cluster, {} walkers to end of cluster", fromStartWalkersNumber, fromEndWalkersNumber);
+        IntStream.range(0, fromStartWalkersNumber + fromEndWalkersNumber).forEach(i -> {
+            if (i < fromStartWalkersNumber) {
+                walkers.add(WalkerBuilder.builder()
+                        .pathFromStart(0)
+                        .isReversed(false)
+                        .longestPathDefault(fromStartWalkersNumber == 2 && i == 0)
+                        .cluster(this)
+                        .currentPoint(new Point(0, 0))
+                        .build());
+            } else {
+                walkers.add(WalkerBuilder.builder()
+                        .isReversed(true)
+                        .pathFromStart(0)
+                        .longestPathDefault(fromEndWalkersNumber == 1 || i == 2)
+                        .cluster(this)
+                        .currentPoint(new Point(endConnectionPoint.getX() - startConnectionPoint.getX(),
+                                endConnectionPoint.getY() - startConnectionPoint.getY()))
+                        .build());
+            }
+        });
+    }
+
+    public void reset() {
+        size = 0;
+        negativeRoomsCount = 0;
+        deadEnds = new ArrayList<>();
+        clusterExpectedWeight = null;
+        walkers = new ArrayList<>();
     }
 
     @Override

--- a/src/main/java/org/dungeon/prototype/properties/GenerationProperties.java
+++ b/src/main/java/org/dungeon/prototype/properties/GenerationProperties.java
@@ -28,5 +28,6 @@ public class GenerationProperties {
         private int levelOneGridSize;
         private int gridSizeIncrement;
         private int incrementStep;
+        private int clusterGenerationRetries = 1;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -211,6 +211,7 @@ generation:
     level-one-grid-size: 10
     grid-size-increment: 1
     increment-step: 10
+    cluster-generation-retries: 3
   monsters:
     zombie:
       primary-attack-type: slash


### PR DESCRIPTION
## Summary
- move walker initialization logic into `LevelGridCluster`
- reset walkers when cluster resets
- generate clusters using internal walkers

## Testing
- `sh ./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844df9722e8833386cb564f9dce3581