### PR TITLE
Fix stop command resets chat async state

### DIFF
--- a/src/main/java/org/dungeon/prototype/bot/BotCommandHandler.java
+++ b/src/main/java/org/dungeon/prototype/bot/BotCommandHandler.java
@@ -64,6 +64,7 @@ public class BotCommandHandler {
     }
 
     public void processStopAction(long chatId) {
+        chatStateService.clearChatContext(chatId);
         messageService.sendStopMessage(chatId);
     }
 }

--- a/src/main/java/org/dungeon/prototype/service/message/MessageService.java
+++ b/src/main/java/org/dungeon/prototype/service/message/MessageService.java
@@ -237,7 +237,6 @@ public class MessageService {
                 keyboardService.getDeathMessageInlineKeyboardMarkup());
     }
 
-    @ClearChatContext
     public void sendStopMessage(long chatId) {
         messageSender.sendInfoMessage(chatId, "Bot stopped. to continue game, please send */start* command");
     }

--- a/src/main/java/org/dungeon/prototype/service/state/ChatStateService.java
+++ b/src/main/java/org/dungeon/prototype/service/state/ChatStateService.java
@@ -140,6 +140,7 @@ public class ChatStateService {
             if (!IDLE.equals(chatContext.getChatState()) &&
                     currentTime - chatContext.getLastActiveTime().get() > TIMEOUT_DURATION) {
                 messageService.sendStopMessage(chatId);
+                clearChatContext(chatId);
             }
         });
     }


### PR DESCRIPTION
## Summary
- reset chat context and async tasks when `/stop` is invoked
- send stop message after clearing chat
- clear contexts on timeout since `sendStopMessage` no longer triggers an aspect

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6844f509c61083338947e6e2bc9cebaf