### PR TITLE
Fix column vector retrieval from balance matrix

### DIFF
--- a/src/main/java/org/dungeon/prototype/service/balancing/BalanceMatrixService.java
+++ b/src/main/java/org/dungeon/prototype/service/balancing/BalanceMatrixService.java
@@ -85,15 +85,13 @@ public class BalanceMatrixService {
         if (matrix.length == 0) {
             throw new DungeonPrototypeException("Empty balance matrix for " + name);
         }
-        if (column < matrix[0].length) {
-            return Arrays.stream(matrix)
-                    .mapToDouble(row -> row[column])
-                    .toArray();
+        if (column >= matrix[0].length) {
+            throw new DungeonPrototypeException("Index out of bounds for balance matrix " + name + ": " + column);
         }
-        if (column < matrix.length) { // handle reversed orientation
-            return matrix[column];
-        }
-        throw new DungeonPrototypeException("Index out of bounds for balance matrix " + name + ": " + column);
+
+        return Arrays.stream(matrix)
+                .mapToDouble(row -> row[column])
+                .toArray();
     }
 
     public double[] getBalanceMatrixRowVector(long chatId, String name, int row) {


### PR DESCRIPTION
## Summary
- simplify column vector lookup to avoid transposed access
- throw `DungeonPrototypeException` on invalid index

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6873c0cc4a188333a2b27f70a2d06b79